### PR TITLE
Allow nested directories resources

### DIFF
--- a/lib/themes_for_rails/assets_controller.rb
+++ b/lib/themes_for_rails/assets_controller.rb
@@ -5,13 +5,17 @@ module ThemesForRails
     include ThemesForRails::CommonMethods
     include ThemesForRails::UrlHelpers
     def stylesheets
-      render_asset theme_stylesheet_path_for(params[:theme], params[:asset]), 'text/css'
+      filename = File.basename(params[:asset], File.extname(params[:asset]))
+      render_asset theme_stylesheet_path_for(params[:theme], filename), 'text/css'
     end
     def javascripts
-      render_asset theme_javascript_path_for(params[:theme], params[:asset]), 'text/javascript'
+      filename = File.basename(params[:asset], File.extname(params[:asset]))
+      render_asset theme_javascript_path_for(params[:theme], filename), 'text/javascript'
     end
     def images
-      render_asset theme_image_path_for(params[:theme], params[:asset], params[:extension]), "image/#{params[:extension]}"
+      extension = File.extname(params[:asset])
+      filename = params[:asset].gsub(extension, '')
+      render_asset theme_image_path_for(params[:theme], filename, extension), "image/#{extension.gsub('.', '')}"
     end
   private
     def render_asset(asset, mime_type)
@@ -28,9 +32,7 @@ module ThemesForRails
     def theme_javascript_path_for(name, asset)
       File.join(theme_path_for(name), 'javascripts', "#{asset}.js")
     end
-    def theme_image_path_for(name, asset, extension = nil)
-      extension ||= "png"
-      extension = ".#{extension}"
+    def theme_image_path_for(name, asset, extension = ".png")
       File.join(theme_path_for(name), 'images', "#{asset}#{extension}")
     end
   end

--- a/lib/themes_for_rails/routes.rb
+++ b/lib/themes_for_rails/routes.rb
@@ -1,9 +1,9 @@
 module ThemesForRails
   module Routes
     def themes_for_rails
-      match 'themes/:theme/stylesheets/:asset(.:extension)' => 'themes_for_rails/assets#stylesheets', :as => :base_theme_stylesheet
-      match 'themes/:theme/javascripts/:asset(.:extension)' => 'themes_for_rails/assets#javascripts', :as => :base_theme_javascript
-      match 'themes/:theme/images/:asset(.:extension)' => 'themes_for_rails/assets#images', :as => :base_theme_image
+      match 'themes/:theme/stylesheets/*asset' => 'themes_for_rails/assets#stylesheets', :as => :base_theme_stylesheet
+      match 'themes/:theme/javascripts/*asset' => 'themes_for_rails/assets#javascripts', :as => :base_theme_javascript
+      match 'themes/:theme/images/*asset' => 'themes_for_rails/assets#images', :as => :base_theme_image
     end
   end
 end

--- a/lib/themes_for_rails/url_helpers.rb
+++ b/lib/themes_for_rails/url_helpers.rb
@@ -9,14 +9,14 @@ module ThemesForRails
     end
     module InstanceMethods
       def current_theme_stylesheet_path(asset)
-        base_theme_stylesheet_path(:theme => self.theme_name, :asset => asset, :extension => 'css')
+        base_theme_stylesheet_path(:theme => self.theme_name, :asset => "#{asset}.css")
       end
       def current_theme_javascript_path(asset)
-        base_theme_javascript_path(:theme => self.theme_name, :asset => asset, :extension => 'js')
+        base_theme_javascript_path(:theme => self.theme_name, :asset => "#{asset}.js")
       end
       def current_theme_image_path(asset)
         image, extension = asset.split(".")
-        base_theme_image_path(:theme => self.theme_name, :asset => image, :extension => extension)
+        base_theme_image_path(:theme => self.theme_name, :asset => "#{image}.#{extension}")
       end
     end
   end

--- a/lib/themes_for_rails/view_helpers.rb
+++ b/lib/themes_for_rails/view_helpers.rb
@@ -6,14 +6,13 @@ module ThemesForRails
     end
     module InstanceMethods
       def current_theme_stylesheet_path(asset)
-        base_theme_stylesheet_path(:theme => self.theme_name, :asset => asset, :extension => 'css')
+        base_theme_stylesheet_path(:theme => self.theme_name, :asset => "#{asset}.js")
       end
       def current_theme_javascript_path(asset)
-        base_theme_javascript_path(:theme => self.theme_name, :asset => asset, :extension => 'js')
+        base_theme_javascript_path(:theme => self.theme_name, :asset => "#{asset}.js")
       end
       def current_theme_image_path(asset)
-        image, extension = asset.split(".")
-        self.base_theme_image_path(:theme => self.theme_name, :asset => image, :extension => extension)
+        self.base_theme_image_path(:theme => self.theme_name, :asset => asset)
       end
       alias_method :theme_image_path, :current_theme_image_path
       alias_method :theme_javascript_path, :current_theme_javascript_path

--- a/test/assets_controller_test.rb
+++ b/test/assets_controller_test.rb
@@ -7,25 +7,26 @@ module ThemesForRails
       assert @controller.respond_to?(:stylesheets)
     end
     should "respond with the right stylesheet file when requested" do
-      get 'stylesheets', { :theme => 'default', :asset => 'style', :extension => 'css'}
+      get 'stylesheets', { :theme => 'default', :asset => 'style.css'}
       assert_response :success
       assert_equal @response.content_type, 'text/css'
     end
     should "not be success when the stylesheet file is not found" do
-      get 'stylesheets', { :theme => 'default', :asset => 'oldstyle', :extension => 'css'}
+      get 'stylesheets', { :theme => 'default', :asset => 'oldstyle.css'}
       assert_response :missing
     end
+    
     # javascripts
     should "respond to javascripts" do
       assert @controller.respond_to?(:javascripts)
     end
     should "respond with the right javascript file when requested" do
-      get 'javascripts', { :theme => 'default', :asset => 'app', :extension => 'js'}
+      get 'javascripts', { :theme => 'default', :asset => 'app.js'}
       assert_response :success
       assert_equal @response.content_type, 'text/javascript'
     end
     should "not be success when the javascript file is not found" do
-      get 'javascripts', { :theme => 'default', :asset => 'oldapp', :extension => 'js'}
+      get 'javascripts', { :theme => 'default', :asset => 'oldapp.js'}
       assert_response :missing
     end
     
@@ -34,13 +35,19 @@ module ThemesForRails
       assert @controller.respond_to?(:images)
     end
     should "respond with the right image file when requested" do
-      get 'images', { :theme => 'default', :asset => 'logo', :extension => 'png'}
+      get 'images', { :theme => 'default', :asset => 'logo.png'}
       assert_response :success
       assert_equal @response.content_type, 'image/png'
     end
     should "not be success when the image file is not found" do
-      get 'images', { :theme => 'default', :asset => 'i_am_not_here', :extension => 'jpg'}
+      get 'images', { :theme => 'default', :asset => 'i_am_not_here.jpg'}
       assert_response :missing
+    end
+    
+    should "respond with a nested asset" do
+      get 'images', { :theme => 'default', :asset => 'nested/logo.png'}
+      assert_response :success
+      assert_equal @response.content_type, 'image/png'
     end
   end
 end

--- a/test/routes_test.rb
+++ b/test/routes_test.rb
@@ -7,8 +7,7 @@ module ThemesForRails
         :controller => 'themes_for_rails/assets', 
         :action => 'stylesheets',
         :theme => 'default', 
-        :asset => 'app',
-        :extension => 'css'
+        :asset => 'app.css'
       })
     end
     should "recognize javascripts route" do
@@ -16,8 +15,7 @@ module ThemesForRails
         :controller => 'themes_for_rails/assets', 
         :action => 'javascripts',
         :theme => 'default', 
-        :asset => 'app',
-        :extension => 'js'
+        :asset => 'app.js'
       })
     end
     should "recognize images route" do
@@ -25,8 +23,16 @@ module ThemesForRails
         :controller => 'themes_for_rails/assets', 
         :action => 'images',
         :theme => 'default', 
-        :asset => 'logo',
-        :extension => 'png'
+        :asset => 'logo.png'
+      })
+    end
+    
+    should "recognize nested route" do
+      assert_generates('/themes/default/images/nested/logo.png', { 
+        :controller => 'themes_for_rails/assets', 
+        :action => 'images',
+        :theme => 'default', 
+        :asset => 'nested/logo.png'
       })
     end
   end


### PR DESCRIPTION
This patch allows nested directories in static files.
For example you can now have an image in `themes/default/images/icons/myicon.png`.
