### PR TITLE
FIX when using a private custom theme method

### DIFF
--- a/lib/themes_for_rails/common_methods.rb
+++ b/lib/themes_for_rails/common_methods.rb
@@ -7,7 +7,7 @@ module ThemesForRails
       @cached_theme_name ||= begin
         case @theme_name
         when Symbol then 
-          self.respond_to?(@theme_name) ? self.send(@theme_name) : @theme_name.to_s
+          self.respond_to?(@theme_name, true) ? self.send(@theme_name) : @theme_name.to_s
         when String then @theme_name
         else
           nil

--- a/lib/themes_for_rails/view_helpers.rb
+++ b/lib/themes_for_rails/view_helpers.rb
@@ -21,8 +21,8 @@ module ThemesForRails
       alias_method :theme_javascript_path, :current_theme_javascript_path
       alias_method :theme_stylesheet_path, :current_theme_stylesheet_path
 
-      def theme_image_tag(source)
-        image_tag(theme_image_path(source))
+      def theme_image_tag(source, options = {})
+        image_tag(theme_image_path(source), options)
       end
       
       def theme_javascript_include_tag(*files)

--- a/test/controller_methods_test.rb
+++ b/test/controller_methods_test.rb
@@ -9,6 +9,21 @@ class CustomThemeController < ActionController::Base
   def hello
     render :text => "Just a test"
   end
+  
+  def theme_selector
+    'custom'
+  end
+end
+class PrivateCustomThemeController < ActionController::Base
+  def hello
+    render :text => "Just a test"
+  end
+
+  private
+  
+  def private_theme_selector
+    'private_custom'
+  end
 end
 
 class ActionMailerInclusionTest < Test::Unit::TestCase
@@ -46,11 +61,18 @@ module ThemesForRails
       end
       context "setting the theme with a Symbol" do
         tests CustomThemeController
-        should "call the selected method" do
-          @controller.expects(:theme_selector).returns('custom')
+        should "call the selected private method" do
           CustomThemeController.theme :theme_selector
-          assert_equal nil, @controller.theme_name
           get :hello
+          assert_equal 'custom', @controller.theme_name
+        end
+      end
+      context "setting the theme with a Symbol" do
+        tests PrivateCustomThemeController
+        should "call the selected private method" do
+          PrivateCustomThemeController.theme :private_theme_selector
+          get :hello
+          assert_equal 'private_custom', @controller.theme_name
         end
       end
     end

--- a/test/view_helpers_test.rb
+++ b/test/view_helpers_test.rb
@@ -23,5 +23,9 @@ module ThemesForRails
     should 'delegate options (lazy testing, I know)' do
       assert theme_stylesheet_link_tag('cuac.css', :media => 'print').include?('media="print"')
     end
+    
+    should 'delegate to image_tag with options' do
+      assert theme_image_tag('logo.png', :alt => 'This is a Logo').include?('alt="This is a Logo"')
+    end
   end
 end


### PR DESCRIPTION
Hi Lucas,

Little quirk I found when updating my app to Rails3 and themes_for_rails; this wouldn't work:

```
class ApplicationController < ActionController::Base
    theme :custom

    private
    def custom
      'some_theme'
    end
end
```

Because by default respond_to? wont tell you if there is a private method.

FYI I have changed the tests slightly as it seemed a bit odd to be testing nil then calling the get request and not actually testing for the correct custom theme_name - perhaps I'm missing something though?  Feel free to modify the tests to how you prefer them though.

Also I left it out of the commit but wonder if it's worth updating the gem file for rails 3.0.3 (or ~> 3.0)? (And possibly rspec-rails ~>2.4?)

Cheers
Luke
