### PR TITLE
themes:create_cache copies only existing subdirs of themes

### DIFF
--- a/lib/tasks/themes_for_rails.rake
+++ b/lib/tasks/themes_for_rails.rake
@@ -6,11 +6,9 @@ namespace :themes do
       theme_dir = ThemesForRails.config.themes_dir
       theme_base = "#{Rails.public_path}/#{theme_dir}/#{theme_name}"
       puts "Creating #{theme_base}"
-  
-      FileUtils.mkdir_p "#{theme_base}"      
-      FileUtils.cp_r "#{theme}/images", "#{theme_base}/images", :verbose => true
-      FileUtils.cp_r "#{theme}/stylesheets", "#{theme_base}/stylesheets", :verbose => true
-      FileUtils.cp_r "#{theme}/javascripts", "#{theme_base}/javascripts", :verbose => true
+
+      FileUtils.mkdir_p "#{theme_base}"
+      FileUtils.cp_r Dir["#{theme}/{images,stylesheets,javascripts}"], theme_base, :verbose => true
     end
   end
   desc "Removes the cached (public) theme folders"


### PR DESCRIPTION
Hey, man! How are you?

I tried to use `rake themes:create_cache` but it failed :(
In my themes I didn't have the javascript dir, so the task barfed with this:

```
unknown file type: /Users/admin/Code54/simplicar/app/themes/amex_es/javascripts
```

Didn't have time to add tests (and couldn't found any for the rake tasks)
Feel free to give any feedback :)

Cheers,
