### PR TITLE
Support for Rails 3.1 with asset pipeline disabled

### DIFF
--- a/lib/generators/themes_for_rails/install_generator.rb
+++ b/lib/generators/themes_for_rails/install_generator.rb
@@ -5,15 +5,15 @@ module ThemesForRails
       desc "Creates a ThemeForRails themes folder with default theme inside."
 
       def create_themes_folder
-        empty_directory ThemesForRails.config.themes_dir
-        create_file "#{ThemesForRails.config.themes_dir}/.gitkeep", ""
+        empty_directory ThemesForRails.config.themes_path
+        create_file "#{ThemesForRails.config.themes_path}/.gitkeep", ""
         inject_into_class "app/controllers/application_controller.rb", ApplicationController do
           "  theme 'default'\n"
         end
 
-        if yes?("\nMove all your views and assets to #{ThemesForRails.config.themes_dir}/default (y/n)?")
+        if yes?("\nMove all your views and assets to #{ThemesForRails.config.themes_path}/default (y/n)?")
           # Create empty directory for default themes
-          default_theme_dir = "#{ThemesForRails.config.themes_dir}/default"
+          default_theme_dir = "#{ThemesForRails.config.themes_path}/default"
           empty_directory default_theme_dir
 
           # TODO: need check for git (or git repo?). If git available, move with git mv command

--- a/lib/generators/themes_for_rails/theme_generator.rb
+++ b/lib/generators/themes_for_rails/theme_generator.rb
@@ -5,7 +5,7 @@ module ThemesForRails
       desc "Creates an empty theme."
       
       def create_theme
-        theme_dir = File.join(ThemesForRails.config.themes_dir, name)
+        theme_dir = File.join(ThemesForRails.config.themes_path, name)
         directory 'theme', theme_dir
       end
     end

--- a/lib/tasks/themes_for_rails.rake
+++ b/lib/tasks/themes_for_rails.rake
@@ -3,7 +3,7 @@ namespace :themes do
   task :create_cache => :environment do
     for theme in ThemesForRails.available_themes
       theme_name = File.basename(theme)
-      theme_dir = ThemesForRails.config.themes_dir
+      theme_dir = ThemesForRails.config.themes_path
       theme_base = "#{Rails.public_path}/#{theme_dir}/#{theme_name}"
       puts "Creating #{theme_base}"
 
@@ -13,7 +13,7 @@ namespace :themes do
   end
   desc "Removes the cached (public) theme folders"
   task :remove_cache => :environment do
-    theme_dir = ThemesForRails.config.themes_dir
+    theme_dir = ThemesForRails.config.themes_path
     puts "Removing #{Rails.public_path}/#{theme_dir}"
     FileUtils.rm_r "#{Rails.public_path}/#{theme_dir}", :force => true
   end

--- a/lib/themes_for_rails.rb
+++ b/lib/themes_for_rails.rb
@@ -16,7 +16,7 @@ module ThemesForRails
     end
 
     def available_themes(&block)
-      Dir.glob(File.join(config.themes_dir, "*"), &block)
+      Dir.glob(File.join(config.themes_path, "*"), &block)
     end
 
     alias each_theme_dir available_themes

--- a/lib/themes_for_rails/assets_finder.rb
+++ b/lib/themes_for_rails/assets_finder.rb
@@ -36,7 +36,7 @@ module ThemesForRails::AssetsFinder
 
   # Generate path for assets by theme name and asset type
   def assets_path_for(theme_name, asset_type)
-    File.join(ThemesForRails.config.themes_dir, theme_name, 'assets', asset_type.to_s)
+    File.join(ThemesForRails.config.themes_path, theme_name, 'assets', asset_type.to_s)
   end
 
 end

--- a/lib/themes_for_rails/common_methods.rb
+++ b/lib/themes_for_rails/common_methods.rb
@@ -1,5 +1,9 @@
 module ThemesForRails
   module CommonMethods
+    def view_path_for(theme)
+      File.join(theme_path_for(theme), "views")
+    end
+
     def theme_name
       @cached_theme_name ||= begin
         case @theme_name
@@ -29,7 +33,7 @@ module ThemesForRails
 
     # Generate path for assets by theme name and asset type
     def assets_path_for(theme_name, asset_type)
-      File.join(ThemesForRails.config.themes_dir, theme_name, 'assets', asset_type.to_s)
+      File.join(ThemesForRails.config.themes_path, theme_name, 'assets', asset_type.to_s)
     end
 
     # Check theme is valid
@@ -39,11 +43,27 @@ module ThemesForRails
 
     # Add view path for current theme
     def add_theme_view_path
-      prepend_view_path(ActionView::FileSystemResolver.new(views_path_for(self.theme_name)))
+      if Rails.application.config.assets.enabled
+        prepend_view_path(ActionView::FileSystemResolver.new(views_path_for(self.theme_name)))
+      else
+        add_theme_view_path_for(self.theme_name)
+      end
+    end
+
+    def add_theme_view_path_for(name)
+      self.view_paths.insert 0, ActionView::FileSystemResolver.new(view_path_for(name))
     end
 
     def views_path_for(theme_name)
-      File.join(ThemesForRails.config.themes_dir, theme_name, 'views')
+      File.join(ThemesForRails.config.themes_path, theme_name, 'views')
+    end
+
+    def theme_path(base = ThemesForRails.config.base_dir)
+      theme_path_for(theme_name, base)
+    end
+
+    def theme_path_for(name, base = ThemesForRails.config.base_dir, theme_dir = ThemesForRails.config.themes_dir)
+      File.join(base, theme_dir, name)
     end
     
     def add_theme_assets_path

--- a/lib/themes_for_rails/config.rb
+++ b/lib/themes_for_rails/config.rb
@@ -1,5 +1,8 @@
 module ThemesForRails
   class Config
+
+    attr_writer :base_dir
+
     def initialize(&block)
       yield if block_given?
     end
@@ -8,12 +11,20 @@ module ThemesForRails
       Rails.application.assets
     end
 
-    def themes_dir=(path)
-      @themes_dir = File.join(Rails.root, path)
+    def base_dir
+      @base_dir ||= Rails.root
     end
-    
+
+    def themes_dir=(path)
+      @themes_dir = path
+    end
+
     def themes_dir
-      @themes_dir ||= File.join(Rails.root, "app/themes")
+      @themes_dir ||= "app/themes"
+    end
+
+    def themes_path
+      File.join(base_dir, themes_dir)
     end
 
     def clear

--- a/lib/themes_for_rails/railtie.rb
+++ b/lib/themes_for_rails/railtie.rb
@@ -2,14 +2,14 @@ module ThemesForRails
   class Railtie < ::Rails::Railtie
 
     config.themes_for_rails = ActiveSupport::OrderedOptions.new
-
-    initializer 'themes_for_rails.initialize', :before=> 'sprockets.environment' do
-
-      raise "Sprockets not enabled" unless Rails.application.config.assets.enabled
-
-      Sprockets::Environment.send :include, ThemesForRails::AssetsFinder
-
-    end
+    #
+    #initializer 'themes_for_rails.initialize', :before=> 'sprockets.environment' do
+    #
+    #  raise "Sprockets not enabled" unless Rails.application.config.assets.enabled
+    #
+    #  Sprockets::Environment.send :include, ThemesForRails::AssetsFinder
+    #
+    #end
 
     config.to_prepare do
       ThemesForRails::Railtie.config.themes_for_rails.each do |key, value|

--- a/lib/themes_for_rails/railtie.rb
+++ b/lib/themes_for_rails/railtie.rb
@@ -2,14 +2,14 @@ module ThemesForRails
   class Railtie < ::Rails::Railtie
 
     config.themes_for_rails = ActiveSupport::OrderedOptions.new
-    #
-    #initializer 'themes_for_rails.initialize', :before=> 'sprockets.environment' do
-    #
-    #  raise "Sprockets not enabled" unless Rails.application.config.assets.enabled
-    #
-    #  Sprockets::Environment.send :include, ThemesForRails::AssetsFinder
-    #
-    #end
+    
+    initializer 'themes_for_rails.initialize', :before=> 'sprockets.environment' do
+    
+      if Rails.application.config.assets.enabled
+        Sprockets::Environment.send :include, ThemesForRails::AssetsFinder
+      end
+    
+    end
 
     config.to_prepare do
       ThemesForRails::Railtie.config.themes_for_rails.each do |key, value|

--- a/lib/themes_for_rails/routes.rb
+++ b/lib/themes_for_rails/routes.rb
@@ -3,7 +3,14 @@ require 'themes_for_rails/assets_finder'
 module ThemesForRails
   module Routes
     def themes_for_rails
-      match "/themes/:theme/assets/*asset" => ThemesForRails.config.assets_finder
+      if Rails.application.config.assets.enabled
+        match "/themes/:theme/assets/*asset" => ThemesForRails.config.assets_finder
+      else
+        theme_dir = ThemesForRails.config.themes_dir
+        match "#{theme_dir}/:theme/stylesheets/*asset" => 'themes_for_rails/assets#stylesheets', :as => :base_theme_stylesheet
+        match "#{theme_dir}/:theme/javascripts/*asset" => 'themes_for_rails/assets#javascripts', :as => :base_theme_javascript
+        match "#{theme_dir}/:theme/images/*asset" => 'themes_for_rails/assets#images', :as => :base_theme_image
+      end
     end
   end
 end

--- a/lib/themes_for_rails/view_helpers.rb
+++ b/lib/themes_for_rails/view_helpers.rb
@@ -11,16 +11,58 @@ module ThemesForRails
       def current_theme_asset_path(asset)
         theme_asset_path(asset, self.theme_name)
       end
-      alias_method :current_theme_javascript_path, :current_theme_asset_path
-      alias_method :current_theme_stylesheet_path, :current_theme_asset_path
-      alias_method :current_theme_image_path,      :current_theme_asset_path
 
       def theme_asset_path(asset, new_theme_name = self.theme_name, options = {})
         asset_path("/themes/#{new_theme_name}/assets/#{asset}", options)
       end
-      alias_method :theme_image_path, :theme_asset_path
-      alias_method :theme_javascript_path, :theme_asset_path
-      alias_method :theme_stylesheet_path, :theme_asset_path
+
+      def current_theme_stylesheet_path(asset)
+        if Rails.application.config.assets.enabled
+          current_theme_asset_path(asset)
+        else
+          base_theme_stylesheet_path(:theme => self.theme_name, :asset => "#{asset}.css")
+        end
+      end
+
+      def current_theme_javascript_path(asset)
+        if Rails.application.config.assets.enabled
+          current_theme_asset_path(asset)
+        else
+          base_theme_stylesheet_path(:theme => self.theme_name, :asset => "#{asset}.css")
+        end
+      end
+
+      def current_theme_image_path(asset)
+        if Rails.application.config.assets.enabled
+          current_theme_asset_path(asset)
+        else
+          base_theme_image_path(:theme => self.theme_name, :asset => asset)
+        end
+      end
+
+      def theme_stylesheet_path(asset, new_theme_name = self.theme_name)
+        if Rails.application.config.assets.enabled
+          theme_asset_path(asset, new_theme_name)
+        else
+          base_theme_stylesheet_path(:theme => new_theme_name, :asset => "#{asset}.css")
+        end
+      end
+
+      def theme_javascript_path(asset, new_theme_name = self.theme_name)
+        if Rails.application.config.assets.enabled
+          theme_asset_path(asset, new_theme_name)
+        else
+          base_theme_javascript_path(:theme => new_theme_name, :asset => "#{asset}.js")
+        end
+      end
+
+      def theme_image_path(asset, new_theme_name = self.theme_name)
+        if Rails.application.config.assets.enabled
+          theme_asset_path(asset, new_theme_name)
+        else
+          base_theme_image_path(:theme => new_theme_name, :asset => asset)
+        end
+      end
 
       def current_theme_image_tag(source, options = {})
         image_tag(current_theme_image_path(source), options)

--- a/spec/lib/view_helpers_spec.rb
+++ b/spec/lib/view_helpers_spec.rb
@@ -16,6 +16,10 @@ describe ThemesForRails::ViewHelpers do
     end.new(config)
   end
 
+  before(:each) do
+    Rails.application.config.assets.enabled = true
+  end
+
   it "should provide path helpers for common asset formats" do
     helper.theme_image_path('logo.png', 'pink').should == "/themes/pink/assets/logo.png"
     helper.theme_stylesheet_path('app.css', 'pink').should == "/themes/pink/assets/app.css"


### PR DESCRIPTION
I find it amusingly coincidental that you worked on the rails31 upgrade on the exact same day that we had decided to upgrade to rails 3.1.  Thanks for themes_for_rails as it has come in quite handy.

Since disabling the asset pipeline is an option in rails 3.1 and we're doing that as an interim step to our upgrade, I thought you might be interested in these changes.  I know you probably wanted to get rid of some of the old stuff, but I pull some of it back in to allow themes_for_rails to support 3.1 with and without asset pipeline.

You could also relax the gemspec dependency to allow for version below 3.1, but I'd imagine it be just as easy for people not to upgrade beyond 0.4.2 on Rails 3.0.

If you like this, please let me know and I can modify the test suite to test in both conditions (asset pipeline enabled and disabled).  Once again thanks and its good to see you're actively maintaining.
