### PR TITLE
Ruby 1.8 compatibility

### DIFF
--- a/lib/themes_for_rails/action_view.rb
+++ b/lib/themes_for_rails/action_view.rb
@@ -44,16 +44,19 @@ module ThemesForRails
     def theme_javascript_include_tag(*files)
       options = files.extract_options!
       options.merge!({ :type => "text/javascript" })
-      files.collect! {|file| theme_javascript_path(file) }
-      javascript_include_tag(*files, options)
+      files_with_options = files.collect {|file| theme_javascript_path(file) }
+      files_with_options += [options]
+
+      javascript_include_tag(*files_with_options)
     end
 
     def theme_stylesheet_link_tag(*files)
       options = files.extract_options!
       options.merge!({ :type => "text/css" })
-      files.collect! {|file| theme_stylesheet_path(file) }
-      stylesheet_link_tag(*files, options)
+      files_with_options = files.collect {|file| theme_stylesheet_path(file) }
+      files_with_options += [options]
+
+      stylesheet_link_tag(*files_with_options)
     end
   end
 end
-


### PR DESCRIPTION
Fix for issue #53. All tests pass on 1.8.7 and 1.9.3.
