### PR TITLE
Fix Ruby 1.9 "can't convert Pathname to String (TypeError)" error

### DIFF
--- a/lib/themes_for_rails/interpolation.rb
+++ b/lib/themes_for_rails/interpolation.rb
@@ -3,7 +3,7 @@ module ThemesForRails
   module Interpolation
 
     def interpolate(pattern, name = nil)
-      pattern.gsub(":root", ThemesForRails.config.base_dir).gsub(":name", name.to_s)
+      pattern.gsub(":root", ThemesForRails.config.base_dir.to_s).gsub(":name", name.to_s)
     end
 
   end


### PR DESCRIPTION
This error happened to me after upgrading Rails to 3.2.8. 
