### PR TITLE
Rails 4 Compatible Routes

### DIFF
--- a/lib/themes_for_rails/routes.rb
+++ b/lib/themes_for_rails/routes.rb
@@ -7,11 +7,11 @@ module ThemesForRails
       constraints = { :theme => /[\w\.]*/ } 
       
       match "#{theme_dir}/:theme/stylesheets/*asset" => 'themes_for_rails/assets#stylesheets', 
-        :as => :base_theme_stylesheet, :constraints => constraints
+        :as => :base_theme_stylesheet, :constraints => constraints, :via => :get
       match "#{theme_dir}/:theme/javascripts/*asset" => 'themes_for_rails/assets#javascripts', 
-        :as => :base_theme_javascript, :constraints => constraints
+        :as => :base_theme_javascript, :constraints => constraints, :via => :get
       match "#{theme_dir}/:theme/images/*asset" => 'themes_for_rails/assets#images', 
-        :as => :base_theme_image, :constraints => constraints
+        :as => :base_theme_image, :constraints => constraints, :via => :get
     end
 
   end


### PR DESCRIPTION
Added `:via => :get` to the routes to make them compatible with rails 4 
