### PR TITLE
bugfix: route definitions in rails 4

### DIFF
--- a/lib/themes_for_rails/routes.rb
+++ b/lib/themes_for_rails/routes.rb
@@ -6,11 +6,11 @@ module ThemesForRails
       theme_dir = ThemesForRails.config.themes_routes_dir
       constraints = { :theme => /[\w\.]*/ } 
       
-      match "#{theme_dir}/:theme/stylesheets/*asset" => 'themes_for_rails/assets#stylesheets', 
+      get "#{theme_dir}/:theme/stylesheets/*asset" => 'themes_for_rails/assets#stylesheets', 
         :as => :base_theme_stylesheet, :constraints => constraints
-      match "#{theme_dir}/:theme/javascripts/*asset" => 'themes_for_rails/assets#javascripts', 
+      get "#{theme_dir}/:theme/javascripts/*asset" => 'themes_for_rails/assets#javascripts', 
         :as => :base_theme_javascript, :constraints => constraints
-      match "#{theme_dir}/:theme/images/*asset" => 'themes_for_rails/assets#images', 
+      get "#{theme_dir}/:theme/images/*asset" => 'themes_for_rails/assets#images', 
         :as => :base_theme_image, :constraints => constraints
     end
 


### PR DESCRIPTION
Rails 4 dose not support `match` any more
