### PR TITLE
Fixed `SystemStackError: stack level too deep' issue

### DIFF
--- a/lib/themes_for_rails/assets_controller.rb
+++ b/lib/themes_for_rails/assets_controller.rb
@@ -17,7 +17,7 @@ module ThemesForRails
     end
 
   private
-    
+
     def handle_asset(prefix)
       asset, theme = params[:asset], params[:theme]
       find_themed_asset(asset, theme, prefix) do |path, mime_type|
@@ -26,14 +26,14 @@ module ThemesForRails
         send_file path, :type => mime_type, :disposition => "inline"
       end
     end
-    
+
     def find_themed_asset(asset_name, asset_theme, asset_type, &block)
       path = asset_path(asset_name, asset_theme, asset_type)
       if File.exists?(path)
         yield path, mime_type_for(request)
-      elsif File.extname(path).blank?
+      elsif File.extname(path).blank? && extension_from(request.path_info).present?
         asset_name = "#{asset_name}.#{extension_from(request.path_info)}"
-        return find_themed_asset(asset_name, asset_theme, asset_type, &block) 
+        return find_themed_asset(asset_name, asset_theme, asset_type, &block)
       else
         render_not_found
       end
@@ -46,21 +46,21 @@ module ThemesForRails
     def render_not_found
       render :text => 'Not found', :status => 404
     end
-      
+
     def mime_type_for(request)
       existing_mime_type = mime_type_from_uri(request.path_info)
-      unless existing_mime_type.nil? 
+      unless existing_mime_type.nil?
         existing_mime_type.to_s
       else
         "image/#{extension_from(request.path_info)}"
       end
     end
-    
+
     def mime_type_from_uri(path)
       extension = extension_from(path)
       Mime::Type.lookup_by_extension(extension)
     end
-    
+
     def extension_from(path)
       File.extname(path).to_s[1..-1]
     end

--- a/test/lib/assets_controller_test.rb
+++ b/test/lib/assets_controller_test.rb
@@ -2,9 +2,9 @@
 require File.expand_path("test/test_helper.rb")
 
 module ThemesForRails
-  class AssetsControllerTest < ::ActionController::TestCase  
+  class AssetsControllerTest < ::ActionController::TestCase
     tests ThemesForRails::AssetsController
-    
+
     should "respond to stylesheets" do
       assert @controller.respond_to?(:stylesheets)
     end
@@ -14,12 +14,19 @@ module ThemesForRails
       assert_response :success
       assert_equal @response.content_type, 'text/css'
     end
-    
+
     should "not be success when the stylesheet file is not found" do
       get 'stylesheets', { :theme => 'default', :asset => 'oldstyle.css'}
       assert_response :missing
     end
-    
+
+    should "not raise an exception with a missing extension" do
+      assert_nothing_raised do
+        get 'stylesheets', { :theme => 'default', :asset => 'style'}
+      end
+      assert_response :missing
+    end
+
     # javascripts
     should "respond to javascripts" do
       assert @controller.respond_to?(:javascripts)
@@ -41,7 +48,7 @@ module ThemesForRails
       get 'javascripts', { :theme => 'default', :asset => 'oldapp.js'}
       assert_response :missing
     end
-    
+
     # images
     should "respond to images" do
       assert @controller.respond_to?(:images)
@@ -52,18 +59,18 @@ module ThemesForRails
       assert_response :success
       assert_equal  'image/png', @response.content_type
     end
-    
+
     should "not be success when the image file is not found" do
       get 'images', { :theme => 'default', :asset => 'i_am_not_here.jpg'}
       assert_response :missing
     end
-    
+
     should "respond with a nested asset" do
       get 'images', { :theme => 'default', :asset => 'nested/logo.png'}
       assert_response :success
       assert_equal 'image/png', @response.content_type
     end
-    
+
     should "respond with properly even when requesting an image inside the stylesheets folder" do
       get 'stylesheets', { :theme => 'default', :asset => 'images/logo.png'}
       assert_response :success


### PR DESCRIPTION
Files without extension cause "SystemStackError: stack level too deep" error
