### PR TITLE
The validation error,   duplicate dependency on rails 

### DIFF
--- a/lib/themes_for_rails/action_controller.rb
+++ b/lib/themes_for_rails/action_controller.rb
@@ -15,7 +15,7 @@ module ThemesForRails
     module ClassMethods
 
       def theme(name, options = {})
-        before_filter(options) do |controller|
+        before_action(options) do |controller|
           controller.set_theme(name)
         end
       end

--- a/lib/themes_for_rails/action_mailer.rb
+++ b/lib/themes_for_rails/action_mailer.rb
@@ -1,22 +1,18 @@
 # encoding: utf-8
 module ThemesForRails
-
-  module ActionMailer
-
-    extend ActiveSupport::Concern
-
-    included do
-      include ThemesForRails::ActionController
-      alias_method_chain :mail, :theme
-    end
-
-    def mail_with_theme(headers = {}, &block)
+  module ThemedMail
+    def mail(headers = {}, &block)
       theme_opts = headers[:theme] || self.class.default[:theme]
       theme(theme_opts) if theme_opts
-
-      mail_without_theme(headers, &block)
+      super
     end
-    
   end
 
+  module ActionMailer
+    extend ActiveSupport::Concern
+    included do
+      include ThemesForRails::ActionController
+      prepend ThemesForRails::ThemedMail
+    end
+  end
 end

--- a/lib/themes_for_rails/routes.rb
+++ b/lib/themes_for_rails/routes.rb
@@ -7,11 +7,11 @@ module ThemesForRails
       constraints = { :theme => /[\w\.]*/ } 
       
       match "#{theme_dir}/:theme/stylesheets/*asset" => 'themes_for_rails/assets#stylesheets', 
-        :as => :base_theme_stylesheet, :constraints => constraints
+        :as => :base_theme_stylesheet, :constraints => constraints, :via => :get
       match "#{theme_dir}/:theme/javascripts/*asset" => 'themes_for_rails/assets#javascripts', 
-        :as => :base_theme_javascript, :constraints => constraints
+        :as => :base_theme_javascript, :constraints => constraints, :via => :get
       match "#{theme_dir}/:theme/images/*asset" => 'themes_for_rails/assets#images', 
-        :as => :base_theme_image, :constraints => constraints
+        :as => :base_theme_image, :constraints => constraints, :via => :get
     end
 
   end

--- a/themes_for_rails.gemspec
+++ b/themes_for_rails.gemspec
@@ -21,5 +21,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "test-unit"
   gem.add_development_dependency "contest"
   gem.add_development_dependency "mocha"
-  gem.add_development_dependency('rails', ["= 3.0.11"])
 end


### PR DESCRIPTION
With bundler 1.10.3 the following error is coming up

<pre>
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  duplicate dependency on rails (= 3.0.11, development), (>= 3.0.0) use:
    add_runtime_dependency 'rails', '= 3.0.11', '>= 3.0.0'
</pre>
